### PR TITLE
fix: leaflet.elevation element selection bug

### DIFF
--- a/graz.html
+++ b/graz.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Graz</title>
-    
+
 
     <!-- leaflet -->
 
@@ -17,9 +17,9 @@
 
    <link href='js/fullscreen/dist/leaflet.fullscreen.css' rel='stylesheet' />
    <script src='js/fullscreen/dist/Leaflet.fullscreen.min.js'></script>
-  
+
     <!-- marker cluster -->
-  
+
    <link rel="stylesheet" href="js/marker.cluster/MarkerCluster.css" />
    <link rel="stylesheet" href="js/marker.cluster/MarkerCluster.Default.css" />
    <script src="js/marker.cluster/leaflet.markercluster-src.js"></script>
@@ -29,7 +29,7 @@
     <script src="js/leaflet.gpx/gpx.js"></script>
     <script src="js/d3/d3.v3.min.js" charset="utf-8"></script>
     <link rel="stylesheet" href="js/leaflet.elevation/leaflet.elevation-0.0.4.css" />
-    <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.min.js"></script>
+    <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.src.js"></script>
 
     <!-- map js  -->
 
@@ -42,11 +42,11 @@
    <script src="daten/graz_heime.js"></script>
    <script src="daten/graz_lokale.js"></script>
    <script src="daten/graz_uni.js"></script>
-     
+
     <!-- css & font  -->
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css" /> 
-   
+    <link rel="stylesheet" href="styles.css" />
+
 </head>
 
 <br>
@@ -122,7 +122,7 @@
             <li><a target="_blank" href = "https://www.uni-graz.at">Universität Graz </a>
             <li><a target="_blank" href = "https://graz.univiertel.at">Tipps zum Ausgehen in Graz </a>
         </ul>
-    
+
    <br>
 
    <div id="map" style="width:1140px;height:600px;" ></div>
@@ -146,7 +146,7 @@
        </ul>
     </center>
     </div>
-   
+
 
    <br>
    <br>

--- a/innsbruck.html
+++ b/innsbruck.html
@@ -16,13 +16,13 @@
 
    <link href='js/fullscreen/dist/leaflet.fullscreen.css' rel='stylesheet' />
    <script src='js/fullscreen/dist/Leaflet.fullscreen.min.js'></script>
-  
+
     <!-- marker cluster -->
-  
+
    <link rel="stylesheet" href="js/marker.cluster/MarkerCluster.css" />
    <link rel="stylesheet" href="js/marker.cluster/MarkerCluster.Default.css" />
    <script src="js/marker.cluster/leaflet.markercluster-src.js"></script>
-   
+
     <!-- Daten -->
 
    <script src="daten/ibk_heime.js"></script>
@@ -35,18 +35,18 @@
    <script src="js/leaflet.gpx/gpx.js"></script>
    <script src="js/d3/d3.v3.min.js" charset="utf-8"></script>
    <link rel="stylesheet" href="js/leaflet.elevation/leaflet.elevation-0.0.4.css" />
-   <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.min.js"></script>
+   <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.src.js"></script>
 
     <!-- map js  -->
 
    <script defer src="innsbruck.js"></script>
    <script defer src="ibk_w.js"></script>
    <script defer src="ibk_w2.js"></script>
-     
+
     <!-- css  -->
 
-    <link rel="stylesheet" href="styles.css" /> 
-   
+    <link rel="stylesheet" href="styles.css" />
+
 </head>
 
 <br>

--- a/js/leaflet.elevation/leaflet.elevation-0.0.4.src.js
+++ b/js/leaflet.elevation/leaflet.elevation-0.0.4.src.js
@@ -482,7 +482,8 @@ L.Control.Elevation = L.Control.extend({
 
             if (!this._mouseHeightFocus) {
 
-                var heightG = d3.select(".leaflet-overlay-pane svg")
+                var heightG = d3.select(this._map.getContainer())
+                    .select(".leaflet-overlay-pane svg")
                     .append("g");
                 this._mouseHeightFocus = heightG.append('svg:line')
                     .attr("class", opts.theme + " height-focus line")

--- a/salzburg.html
+++ b/salzburg.html
@@ -34,7 +34,7 @@
    <script src="js/leaflet.gpx/gpx.js"></script>
    <script src="js/d3/d3.v3.min.js" charset="utf-8"></script>
    <link rel="stylesheet" href="js/leaflet.elevation/leaflet.elevation-0.0.4.css" />
-   <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.min.js"></script>
+   <script type="text/javascript" src="js/leaflet.elevation/leaflet.elevation-0.0.4.src.js"></script>
 
     <!-- map js  -->
 


### PR DESCRIPTION
Der Fehler liegt in der Leaflet.elevation Bibliothek: Wenn mehrere Leaflet-Karten auf einer Seite verwendet werden ist nicht garantiert auf welcher Karte der Marker angezeigt wird.


see: https://github.com/MrMufflon/Leaflet.Elevation/pull/78